### PR TITLE
Support different analog port

### DIFF
--- a/coe/ta-cmi-coe-out.js
+++ b/coe/ta-cmi-coe-out.js
@@ -19,7 +19,8 @@ module.exports = function(RED) {
 	        	buf.writeUInt8(nodeid, 0);
 			buf.writeUInt16LE(value, 2);
 		} else {
-			buf.writeUInt8(1, 1);
+                        var group = Math.floor(((port-17)/4)+1);
+			buf.writeUInt8(group, 1);
 	        	buf.writeUInt8(nodeid, 0);
 			buf.writeUInt16LE(value, 2);
 		}


### PR DESCRIPTION
Add support for analog ports other than 17 (1). However only no more than one port per groud should be used. The reason is that all other ports within the same group will send 0 and that might override existing values.