### PR TITLE
Workaround wrong unit

### DIFF
--- a/coe/ta-cmi-coe-in.js
+++ b/coe/ta-cmi-coe-in.js
@@ -16,7 +16,7 @@ module.exports = function(RED) {
 					}
 					value = buffer.readInt16LE(i * 2 + 2);
 					var unit = buffer[i + 10];
-					if (unit == 1) {
+					if (unit == 1 || unit == 255) {
 						value = value / 10;
 					}
 					node.send([{

--- a/coe/ta-cmi-coe-in.js
+++ b/coe/ta-cmi-coe-in.js
@@ -16,6 +16,7 @@ module.exports = function(RED) {
 					}
 					value = buffer.readInt16LE(i * 2 + 2);
 					var unit = buffer[i + 10];
+					//unit is wrongly sent as 255 if negativ value
 					if (unit == 1 || unit == 255) {
 						value = value / 10;
 					}


### PR DESCRIPTION
Temperature values are being sent with unit 1. However there seems to be a bug in the CMI firmware (1.24.13) that causes the unit to be set to 255 for negative values. This PR implements a workaround that also devided the values by 10 for unit 255 as well.